### PR TITLE
fix: 修复 GetNetworkTime 在所有请求失败时永久阻塞的问题

### DIFF
--- a/src/time/timeKit/time_network.go
+++ b/src/time/timeKit/time_network.go
@@ -36,6 +36,10 @@ func GetNetworkTime(ctx context.Context) (time.Time, string, error) {
 		time   time.Time
 	}
 
+	// 保证函数内部有超时，防止所有请求失败且ctx无deadline时select永久阻塞
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}


### PR DESCRIPTION
## Summary

- `GetNetworkTime` 中的 `select` 依赖 `ch` 有数据或 `ctx.Done()` 关闭才能退出
- 当所有 HTTP 请求均以错误结束（如网络断开）、且调用方传入无 deadline 的 `context.Background()` 时，两个 case 均永远不就绪，函数**永久阻塞（死锁）**
- 修复方案：在函数内部通过 `context.WithTimeout(ctx, 15s)` 强制加兜底超时，保证函数必然能退出

## Test plan

- [ ] 断网环境下调用 `GetNetworkTime(context.Background())`，确认 15 秒内函数返回错误而非挂死
- [ ] 正常网络环境下调用，确认仍能正确返回网络时间

🤖 Generated with [Claude Code](https://claude.com/claude-code)