### PR TITLE
fix: 修复 GetNetworkTime 所有请求失败时永久阻塞的问题

### DIFF
--- a/src/time/timeKit/time_network.go
+++ b/src/time/timeKit/time_network.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/richelieu042/chimera/v3/src/component/web/httpKit"
@@ -41,8 +42,12 @@ func GetNetworkTime(ctx context.Context) (time.Time, string, error) {
 	}
 
 	ch := make(chan *bean, len(sources))
+
+	var wg sync.WaitGroup
 	for _, source := range sources {
+		wg.Add(1)
 		go func(url string) {
+			defer wg.Done()
 			t, err := getNetworkTimeByUrl(ctx, client, url)
 			if err != nil {
 				return
@@ -55,8 +60,16 @@ func GetNetworkTime(ctx context.Context) (time.Time, string, error) {
 		}(source)
 	}
 
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
 	select {
-	case b := <-ch:
+	case b, ok := <-ch:
+		if !ok {
+			return time.Time{}, "", errKit.New("all network time sources failed")
+		}
 		return b.time, b.source, nil
 	case <-ctx.Done():
 		return time.Time{}, "", ctx.Err()


### PR DESCRIPTION
## 问题

当所有网络请求均失败时，`GetNetworkTime` 函数会永久阻塞。

**根本原因**：所有 goroutine 失败后不向 `ch` 发送数据，而 `select` 只有两个 case：
- `case b := <-ch`：永远收不到数据
- `case <-ctx.Done()`：若 ctx 无 deadline（如 `context.Background()`），永远不触发

## 修复

使用 `sync.WaitGroup` 追踪所有 goroutine 的完成情况，全部结束后关闭 channel，`select` 通过 `ok` 标志检测 channel 关闭，返回明确的错误而非永久阻塞。

## 变更

- 引入 `sync.WaitGroup`，每个 goroutine 调用 `wg.Done()`
- 启动单独的 goroutine 在所有请求完成后 `close(ch)`
- `select` 改为 `case b, ok := <-ch`，`ok == false` 时返回 `"all network time sources failed"` 错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)