### PR TITLE
refactor: change GetNetworkTime parameter from context.Context to time.Duration

### DIFF
--- a/src/time/timeKit/time_network.go
+++ b/src/time/timeKit/time_network.go
@@ -25,19 +25,22 @@ var sources = []string{
 /*
 !!!: 方法体内不要直接使用 reqKit，以防import cycle.
 
-@param ctx 不能为nil
+@param timeout 超时时间
 @return time.Time 	获取到的网络时间
 		string		网络时间的来源
 		error		错误
 */
-func GetNetworkTime(ctx context.Context) (time.Time, string, error) {
+func GetNetworkTime(timeout time.Duration) (time.Time, string, error) {
 	type bean struct {
 		source string
 		time   time.Time
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	client := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout: timeout,
 	}
 
 	ch := make(chan *bean, len(sources))

--- a/src/time/timeKit/time_network.go
+++ b/src/time/timeKit/time_network.go
@@ -60,6 +60,7 @@ func GetNetworkTime(timeout time.Duration) (time.Time, string, error) {
 
 	select {
 	case b := <-ch:
+		cancel()
 		return b.time, b.source, nil
 	case <-ctx.Done():
 		return time.Time{}, "", ctx.Err()


### PR DESCRIPTION
## Summary

- 将 `GetNetworkTime` 的参数从 `context.Context` 改为 `time.Duration`
- 函数内部通过 `context.WithTimeout` 创建 ctx 并 `defer cancel()`
- `http.Client.Timeout` 改用传入的 `timeout`，不再硬编码 10s

## Test plan

- [ ] 调用方传入 `time.Duration`（如 `10 * time.Second`）验证正常获取网络时间
- [ ] 传入较短超时（如 `1 * time.Millisecond`）验证超时错误正确返回

🤖 Generated with [Claude Code](https://claude.com/claude-code)