### PR TITLE
fix: avoid dropping valid result when context and channel are both ready

### DIFF
--- a/src/time/timeKit/time_network.go
+++ b/src/time/timeKit/time_network.go
@@ -69,6 +69,13 @@ func GetNetworkTime(ctx context.Context) (time.Time, string, error) {
 		}
 		return b.time, b.source, nil
 	case <-ctx1.Done():
+		select {
+		case b, ok := <-ch:
+			if ok {
+				return b.time, b.source, nil
+			}
+		default:
+		}
 		return time.Time{}, "", ctx1.Err()
 	}
 }


### PR DESCRIPTION
## Summary
- In `GetNetworkTime`, Go's `select` randomly picks between `ch` and `ctx1.Done()` when both are ready simultaneously
- This could cause a valid network time result to be discarded in favor of a context error
- Added a fallback non-blocking read from `ch` inside the `ctx1.Done()` branch to prevent this

## Test plan
- [ ] Verify `GetNetworkTime` returns a valid result even when context cancellation and a successful response race

🤖 Generated with [Claude Code](https://claude.com/claude-code)